### PR TITLE
fixed the issue with audio attachments not being attached

### DIFF
--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -126,27 +126,11 @@ export const sendScheduledEmail = internalAction({
 			const attachments = [];
 			for (const component of updatedComponents) {
 				if (component.type === "audio" && component.audioUrl) {
-					try {
-						// Fetch the audio file
-						const response = await fetch(component.audioUrl);
-						if (!response.ok) {
-							console.error(
-								`Failed to fetch audio file: ${response.statusText}`
-							);
-							continue;
-						}
-
-						// Get the audio file as buffer
-						const audioBuffer = await response.arrayBuffer();
-
-						// Add to attachments
-						attachments.push({
-							filename: `${component.title || "Audio Message"}.mp3`,
-							content: Buffer.from(audioBuffer),
-						});
-					} catch (error) {
-						console.error("Error preparing audio attachment:", error);
-					}
+					// Add to attachments using the path format
+					attachments.push({
+						path: component.audioUrl,
+						filename: `${component.title || "Audio Message"}.mp3`,
+					});
 				}
 			}
 


### PR DESCRIPTION
This pull request includes a change to the `sendScheduledEmail` function in the `convex/emails.ts` file. The change simplifies the process of adding audio attachments by using the path format directly instead of fetching and buffering the audio file.

Simplification of audio attachment handling:

* [`convex/emails.ts`](diffhunk://#diff-d321377e795c145443a1b2c0707c701aebb95567c90b0783326d0c5028e20f78L129-L149): Modified the `sendScheduledEmail` function to add audio attachments using the path format directly, removing the need to fetch and buffer the audio file.