### PR TITLE
fixing issues

### DIFF
--- a/src/app/billing/actions.ts
+++ b/src/app/billing/actions.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { env } from "@/env";
 import stripe from "@/lib/stripe";
 import { currentUser } from "@clerk/nextjs/server";
 
@@ -19,9 +18,14 @@ export async function createCustomerPortalSession() {
 		throw new Error("Stripe customer ID not found");
 	}
 
+	const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+	if (!baseUrl) {
+		throw new Error("NEXT_PUBLIC_BASE_URL is not configured");
+	}
+
 	const session = await stripe.billingPortal.sessions.create({
 		customer: stripeCustomerId,
-		return_url: `${env.NEXT_PUBLIC_BASE_URL}/billing`,
+		return_url: `${baseUrl}/billing`,
 	});
 
 	if (!session.url) {

--- a/src/components/providers/ConvexClientProvider.tsx
+++ b/src/components/providers/ConvexClientProvider.tsx
@@ -4,9 +4,14 @@ import { useAuth } from "@clerk/nextjs";
 import { ConvexProviderWithClerk } from "convex/react-clerk";
 import { ConvexReactClient } from "convex/react";
 import { Authenticated, Unauthenticated } from "convex/react";
-import { env } from "@/env";
 
-const convex = new ConvexReactClient(env.NEXT_PUBLIC_CONVEX_URL);
+// Initialize Convex directly with environment variables
+const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL || "";
+if (!convexUrl) {
+	console.warn("NEXT_PUBLIC_CONVEX_URL is not configured");
+}
+
+const convex = new ConvexReactClient(convexUrl);
 
 export function ConvexClientProvider({
 	children,

--- a/src/lib/convex.ts
+++ b/src/lib/convex.ts
@@ -1,4 +1,24 @@
-import { ConvexClient } from "convex/browser";
-import { env } from "@/env";
+import { ConvexHttpClient } from "convex/browser";
 
-export const convex = new ConvexClient(env.NEXT_PUBLIC_CONVEX_URL);
+// Cache the client instance to avoid creating multiple clients
+let clientInstance: ConvexHttpClient | null = null;
+
+/**
+ * Creates a Convex HTTP client that's compatible with Edge runtime
+ * @returns A ConvexHttpClient instance
+ */
+export function getConvexClient(): ConvexHttpClient {
+	const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+	if (!convexUrl) {
+		throw new Error("NEXT_PUBLIC_CONVEX_URL is not configured");
+	}
+
+	// Return cached instance if available
+	if (clientInstance) {
+		return clientInstance;
+	}
+
+	// Create a new instance and cache it
+	clientInstance = new ConvexHttpClient(convexUrl);
+	return clientInstance;
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,49 @@
+/**
+ * Edge-compatible environment variables
+ * This file provides direct access to environment variables without using @t3-oss/env-nextjs
+ * which is not compatible with the Edge runtime
+ */
+
+// Server-side environment variables
+export const serverEnv = {
+	CONVEX_DEPLOYMENT: process.env.CONVEX_DEPLOYMENT || "",
+	CLERK_SECRET_KEY: process.env.CLERK_SECRET_KEY || "",
+	CLERK_WEBHOOK_SECRET: process.env.CLERK_WEBHOOK_SECRET || "",
+	RESEND_API_KEY: process.env.RESEND_API_KEY || "",
+	MAPBOX_API_KEY: process.env.MAPBOX_API_KEY || "",
+	STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY || "",
+	STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET || "",
+	GOOGLE_OAUTH_CLIENT_ID: process.env.GOOGLE_OAUTH_CLIENT_ID || "",
+	GOOGLE_OAUTH_CLIENT_SECRET: process.env.GOOGLE_OAUTH_CLIENT_SECRET || "",
+	GOOGLE_OAUTH_REDIRECT_URI: process.env.GOOGLE_OAUTH_REDIRECT_URI || "",
+	GOOGLE_API_KEY: process.env.GOOGLE_API_KEY || "",
+	OPENAI_API_KEY: process.env.OPENAI_API_KEY || "",
+};
+
+// Client-side environment variables
+export const clientEnv = {
+	NEXT_PUBLIC_CONVEX_URL: process.env.NEXT_PUBLIC_CONVEX_URL || "",
+	NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:
+		process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || "",
+	NEXT_PUBLIC_CLERK_HOSTNAME: process.env.NEXT_PUBLIC_CLERK_HOSTNAME || "",
+	NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:
+		process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || "",
+	NEXT_PUBLIC_STRIPE_PRICE_ID_PRO_MONTHLY:
+		process.env.NEXT_PUBLIC_STRIPE_PRICE_ID_PRO_MONTHLY || "",
+	NEXT_PUBLIC_STRIPE_PRICE_ID_PRO_ANNUAL:
+		process.env.NEXT_PUBLIC_STRIPE_PRICE_ID_PRO_ANNUAL || "",
+	NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL || "",
+	NEXT_PUBLIC_MAPBOX_API_KEY: process.env.NEXT_PUBLIC_MAPBOX_API_KEY || "",
+	NEXT_PUBLIC_CLERK_SIGN_IN_URL:
+		process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL || "",
+	NEXT_PUBLIC_CLERK_SIGN_UP_URL:
+		process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL || "",
+	NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY || "",
+	NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST || "",
+};
+
+// Combined environment variables for convenience
+export const env = {
+	...serverEnv,
+	...clientEnv,
+};

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,6 +1,8 @@
 import Stripe from "stripe";
-import { env } from "@/env";
 
-const stripe = new Stripe(env.STRIPE_SECRET_KEY);
+// Initialize Stripe directly with environment variables
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || "", {
+	apiVersion: "2024-12-18.acacia", // Use the latest API version
+});
 
 export default stripe;


### PR DESCRIPTION
This pull request focuses on refactoring the way environment variables are handled in the codebase to ensure compatibility with the Edge runtime. The changes involve removing the dependency on the `@t3-oss/env-nextjs` package and directly accessing environment variables using `process.env`.

Refactoring environment variable handling:

* [`src/lib/env.ts`](diffhunk://#diff-48fc28ac09c5305215c9178154a6caf8eedb90e42e44183606e9f2ad20311e46R1-R49): Introduced `serverEnv`, `clientEnv`, and `env` objects to provide direct access to environment variables, ensuring compatibility with the Edge runtime.

Updates to environment variable usage:

* [`src/app/billing/actions.ts`](diffhunk://#diff-0331170a86b120c78bee1f27246f2d8fe2af6850035d25cb2ad8891bf424145bR21-R28): Replaced `env.NEXT_PUBLIC_BASE_URL` with `process.env.NEXT_PUBLIC_BASE_URL` for the Stripe return URL in `createCustomerPortalSession`.
* [`src/components/providers/ConvexClientProvider.tsx`](diffhunk://#diff-ea49c66e0f5b438a9c013fffbb20070c5961a74b921e6ce2aa971c1221560d4cL7-R14): Updated the initialization of `ConvexReactClient` to use `process.env.NEXT_PUBLIC_CONVEX_URL` directly and added a warning if the URL is not configured.
* [`src/lib/convex.ts`](diffhunk://#diff-e0922008170cb623400a255b55b71638a860575b5961acddd020ace05cc19086L1-R24): Created a `getConvexClient` function to initialize and cache a `ConvexHttpClient` instance using `process.env.NEXT_PUBLIC_CONVEX_URL`.
* [`src/lib/stripe.ts`](diffhunk://#diff-387e90ded22a91b0793fbeeb01ee87ccc5f4c55b07f36259145eabfb7f771baeL2-R6): Modified the Stripe initialization to use `process.env.STRIPE_SECRET_KEY` directly and specified the latest API version.