### PR TITLE
trying to remove the dupilcate tool calls

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -273,22 +273,15 @@ export default function ChatInterface() {
 		setErrorDetails(null);
 		setErrorType(null);
 
-		// Clear tool history if this is a new conversation (no messages or only user messages)
-		if (
-			messages.length === 0 ||
-			messages[messages.length - 1].role === "user"
-		) {
-			setToolHistory([]);
-			// Also reset the hasReceivedAnswer flag when starting a new conversation
-			setHasReceivedAnswer(false);
-			setHasShownToolHistory(false);
-			processedToolCalls.clear();
+		// Always clear tool history when submitting a new message
+		setToolHistory([]);
+		setHasReceivedAnswer(false);
+		setHasShownToolHistory(false);
+		processedToolCalls.clear();
 
-			// If the conversation ID has changed, update it and clear processed tool calls
-			if (id !== currentConversationId) {
-				setCurrentConversationId(id);
-				processedToolCalls.clear();
-			}
+		// If the conversation ID has changed, update it
+		if (id !== currentConversationId) {
+			setCurrentConversationId(id);
 		}
 
 		handleSubmit(e);
@@ -625,6 +618,7 @@ export default function ChatInterface() {
 												<div className="space-y-2">
 													{/* Only show the most recent tool call if there are duplicates */}
 													{toolHistory
+														// First filter out any duplicate tool calls
 														.filter((tool, index, self) => {
 															// Keep only the last occurrence of each tool name
 															return (
@@ -632,6 +626,8 @@ export default function ChatInterface() {
 																self.findLastIndex((t) => t.name === tool.name)
 															);
 														})
+														// Then sort by start time to ensure consistent order
+														.sort((a, b) => a.startTime - b.startTime)
 														.map((tool, index) => (
 															<motion.div
 																key={tool.id}


### PR DESCRIPTION
This pull request focuses on improving the chat interface by refining the handling of tool history and conversation state management. The key changes include always clearing the tool history when submitting a new message and ensuring the tool history is filtered and sorted consistently.

Improvements to tool history handling:

* [`src/components/chat/ChatInterface.tsx`](diffhunk://#diff-19f1ae22813bac6b832bb0b8e9c25da09612f071cd0e1547ada32013e6200c0bL276-L291): Modified the logic to always clear the tool history when submitting a new message and reset relevant flags. Removed redundant conditions and comments for clarity.

* [`src/components/chat/ChatInterface.tsx`](diffhunk://#diff-19f1ae22813bac6b832bb0b8e9c25da09612f071cd0e1547ada32013e6200c0bR621-R630): Added filtering to remove duplicate tool calls and sorting by start time to ensure a consistent order in the displayed tool history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the chat experience by ensuring consistent handling of message submissions. The display of tool interactions has been enhanced with duplicate entries removed and a consistent ordering applied, resulting in a clearer conversation history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->