### PR TITLE
added a filter to limit the number of events being shown based on use…

### DIFF
--- a/src/components/dashboard/UpcomingEvents.tsx
+++ b/src/components/dashboard/UpcomingEvents.tsx
@@ -23,6 +23,7 @@ export function UpcomingEvents() {
 	if (!recipients || !customEvents) return null;
 
 	const daysToShow = user?.settings?.upcomingEvents?.daysToShow ?? 30;
+	const maxEvents = user?.settings?.upcomingEvents?.maxEvents ?? 10;
 
 	const getDaysUntil = (date: Date) => {
 		const today = new Date();
@@ -54,7 +55,8 @@ export function UpcomingEvents() {
 
 	const allEvents = [...birthdayEvents, ...customEventsList]
 		.filter((event) => event.daysUntil >= 0 && event.daysUntil <= daysToShow)
-		.sort((a, b) => a.daysUntil - b.daysUntil);
+		.sort((a, b) => a.daysUntil - b.daysUntil)
+		.slice(0, maxEvents);
 
 	return (
 		<Card className="w-full upcoming-events" shadow="sm">


### PR DESCRIPTION
This pull request includes changes to the `UpcomingEvents` component in the `src/components/dashboard/UpcomingEvents.tsx` file to enhance its functionality by adding a limit on the number of events displayed.

Enhancements to event display:

* Added a `maxEvents` setting to limit the number of events shown, defaulting to 10 if not specified.
* Modified the event filtering logic to slice the sorted events list to the `maxEvents` limit before rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Upcoming events on the dashboard are now limited based on user settings, with a default maximum of 10 events displayed, ensuring a streamlined view aligned with user preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->