### PR TITLE
add migrations to update user and recipient address structures

### DIFF
--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -1,6 +1,7 @@
 import { Migrations } from "@convex-dev/migrations";
 import { components } from "./_generated/api";
 import { DataModel } from "./_generated/dataModel";
+import { internal } from "./_generated/api";
 
 export const migrations = new Migrations<DataModel>(components.migrations);
 
@@ -19,4 +20,77 @@ export const addUserFields = migrations.define({
 });
 
 // Create a runner specifically for this migration
-export const runAddUserFields = run;
+export const runAddUserFields = migrations.runner(
+	internal.migrations.addUserFields
+);
+
+// Migration to update user address structure
+export const updateUserAddressStructure = migrations.define({
+	table: "users",
+	// Only migrate users who have an address defined
+	customRange: (query) =>
+		query.filter((q) => q.neq(q.field("settings.address"), undefined)),
+	migrateOne: async (ctx, user) => {
+		if (user.settings?.address) {
+			const { city, country, countryCode, coordinates } = user.settings.address;
+			// Create a new address object with only the fields we want to keep
+			const updatedAddress = {
+				city,
+				country,
+				countryCode,
+				coordinates,
+			};
+
+			// Update the user's address with the new structure
+			await ctx.db.patch(user._id, {
+				settings: {
+					...user.settings,
+					address: updatedAddress,
+				},
+			});
+		}
+	},
+});
+
+// Migration to update recipient address structure
+export const updateRecipientAddressStructure = migrations.define({
+	table: "recipients",
+	// Only migrate recipients who have address metadata
+	customRange: (query) =>
+		query.filter((q) => q.neq(q.field("metadata.address"), undefined)),
+	migrateOne: async (ctx, recipient) => {
+		if (recipient.metadata?.address) {
+			const { city, country, coordinates } = recipient.metadata.address;
+			// Create a new address object with only the fields we want to keep
+			const updatedAddress = {
+				city,
+				country,
+				coordinates,
+			};
+
+			// Update the recipient's address with the new structure
+			await ctx.db.patch(recipient._id, {
+				metadata: {
+					...recipient.metadata,
+					address: updatedAddress,
+				},
+			});
+		}
+	},
+});
+
+// Runner for user address structure migration
+export const runUpdateUserAddressStructure = migrations.runner(
+	internal.migrations.updateUserAddressStructure
+);
+
+// Runner for recipient address structure migration
+export const runUpdateRecipientAddressStructure = migrations.runner(
+	internal.migrations.updateRecipientAddressStructure
+);
+
+// Runner to execute both migrations in sequence
+export const runAllAddressUpdates = migrations.runner([
+	internal.migrations.updateUserAddressStructure,
+	internal.migrations.updateRecipientAddressStructure,
+]);


### PR DESCRIPTION
This pull request to `convex/migrations.ts` introduces new migration definitions and runners to update the address structure for users and recipients. The most important changes include the addition of new migration definitions and runners, as well as the modification of an existing runner.

New migration definitions and runners:

* Added import for `internal` from `./_generated/api` to use internal migration definitions.
* Defined `updateUserAddressStructure` migration to update the address structure for users.
* Defined `updateRecipientAddressStructure` migration to update the address structure for recipients.
* Added runners for `updateUserAddressStructure` and `updateRecipientAddressStructure` migrations.
* Created a runner `runAllAddressUpdates` to execute both address update migrations in sequence.