### PR TITLE
update UpcomingEvents component to display the count of upcoming events

### DIFF
--- a/src/components/dashboard/UpcomingEvents.tsx
+++ b/src/components/dashboard/UpcomingEvents.tsx
@@ -68,7 +68,9 @@ export function UpcomingEvents() {
 						<div className="flex items-center justify-between w-full">
 							<div className="flex items-center gap-2">
 								<Calendar className="h-4 w-4 text-primary" />
-								<span className="text-sm font-medium">Upcoming Events</span>
+								<span className="text-sm font-medium">
+									Upcoming Events ({allEvents.length})
+								</span>
 							</div>
 							<div className="text-xs text-gray-500">
 								Next {daysToShow} days


### PR DESCRIPTION
This pull request makes a small enhancement to the `UpcomingEvents` component in `src/components/dashboard/UpcomingEvents.tsx`. The change updates the heading to display the count of upcoming events dynamically.

* [`src/components/dashboard/UpcomingEvents.tsx`](diffhunk://#diff-c9cece9882eaaf2ae70e5fe328e107a88cb48eeebdfcfd54ae178d8be30972b6L71-R73): Modified the heading in the `UpcomingEvents` component to include the count of all upcoming events (`allEvents.length`).