### PR TITLE
enhance optimized search recipients tool to support 'any' search type…

### DIFF
--- a/src/utils/ai-tools/optimized-search-recipients-tool.ts
+++ b/src/utils/ai-tools/optimized-search-recipients-tool.ts
@@ -28,7 +28,7 @@ const sanitizeSearchQuery = (query: string): string => {
 	return query.trim().replace(/[<>\"'&]/g, "");
 };
 
-const detectSearchType = (query: string): "name" | "email" | "birthday" => {
+const detectSearchType = (query: string): "name" | "email" | "birthday" | "any" => {
 	const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 	const birthdayRegex = /^\d{1,2}\/\d{1,2}(?:\/\d{4})?$/;
 	
@@ -71,8 +71,8 @@ export const optimizedSearchRecipientsTool = tool({
 		searchQuery: SearchQuerySchema.describe(
 			"The search query. Can be a name, email, or birthday (MM/DD or MM/DD/YYYY format). Examples: 'John Smith', 'john@email.com', '10/15'"
 		),
-		searchType: SearchTypeEnum.optional().describe(
-			"Type of search to perform. If not specified, will auto-detect based on query format"
+		searchType: SearchTypeEnum.default("any").describe(
+			"Type of search to perform. Use 'any' for auto-detection based on query format"
 		),
 		sessionId: SessionIdSchema.describe("Session ID to track this search request"),
 	}),
@@ -90,8 +90,8 @@ export const optimizedSearchRecipientsTool = tool({
 				throw new SearchValidationError("Search query cannot be empty", "searchQuery");
 			}
 
-			// Auto-detect search type if not provided
-			const finalSearchType = searchType || detectSearchType(sanitizedQuery);
+			// Auto-detect search type if set to "any"
+			const finalSearchType = searchType === "any" ? detectSearchType(sanitizedQuery) : searchType;
 			
 			logAI(
 				LogLevel.DEBUG,


### PR DESCRIPTION
This pull request introduces enhancements to the `optimized-search-recipients-tool` in `src/utils/ai-tools/optimized-search-recipients-tool.ts`. The changes focus on improving the handling of search types by adding a new "any" option for auto-detection and refining the default behavior of the tool.

### Enhancements to search type handling:

* `detectSearchType` function: Added support for a new `"any"` search type to enable more flexible auto-detection based on query format.
* `optimizedSearchRecipientsTool` schema: Updated the `searchType` parameter to default to `"any"` instead of being optional, simplifying usage and ensuring consistent behavior.
* `optimizedSearchRecipientsTool` logic: Adjusted the search type resolution to auto-detect only when `searchType` is explicitly set to `"any"`, providing clearer intent and avoiding ambiguity.… for improved auto-detection