### PR TITLE
fixing responsive recipient page

### DIFF
--- a/src/app/recipients/page.tsx
+++ b/src/app/recipients/page.tsx
@@ -217,7 +217,7 @@ export default function RecipientsPage() {
 		<PageWithStats>
 			<div
 				className={`space-y-6 transition-all duration-300 ${
-					!selectedRecipientId ? "lg:mr-[-200px] lg:pr-[200px]" : ""
+					!selectedRecipientId ? "lg:mr-[-200px] lg:pr-[100px]" : ""
 				}`}
 			>
 				{/* Header */}
@@ -303,7 +303,7 @@ export default function RecipientsPage() {
 					{/* Main Content Area - Uses all available space */}
 					<div className="flex-1 min-w-0">
 						{viewMode === "table" ? (
-							<div className="bg-white rounded-lg border border-default-200 overflow-hidden">
+							<div className="bg-white rounded-lg overflow-hidden">
 								<RecipientsTable onRecipientSelect={handleRecipientSelect} />
 							</div>
 						) : (

--- a/src/components/shared/CollapsibleSidebar.tsx
+++ b/src/components/shared/CollapsibleSidebar.tsx
@@ -139,7 +139,7 @@ export function CollapsibleSidebar({
 					bg-background
 					transition-all duration-300 ease-in-out
 					hidden lg:block
-					${isOpen ? "w-[450px] mr-8" : "w-[60px]"}
+					${isOpen ? "w-[350px] mr-2" : "w-[60px]"}
 				`}
 			>
 				<Button
@@ -155,7 +155,7 @@ export function CollapsibleSidebar({
 					)}
 				</Button>
 
-				<div className="h-full overflow-y-auto p-4">{getSidebarContent()}</div>
+				<div className="h-full overflow-y-auto p-2">{getSidebarContent()}</div>
 			</div>
 
 			{/* Mobile Footer Bar */}

--- a/src/components/shared/PageWithStats.tsx
+++ b/src/components/shared/PageWithStats.tsx
@@ -29,7 +29,7 @@ export function PageWithStats({ children }: PageWithStatsProps) {
 			<div
 				className={`
 					flex-1 transition-all duration-300 ease-in-out pb-16
-					${isSidebarOpen ? "lg:pr-[200px]" : "lg:pr-[60px]"}
+					${isSidebarOpen ? "lg:pr-[450px]" : "lg:pr-[60px]"}
 					lg:pb-0
 				`}
 			>


### PR DESCRIPTION
This pull request focuses on refining the layout and spacing across several components to improve the user interface and responsiveness. The changes primarily adjust widths, paddings, and margins for better alignment and usability, particularly in the sidebar and recipient page components.

### Layout adjustments in `RecipientsPage`:

* [`src/app/recipients/page.tsx`](diffhunk://#diff-59e6d39b429c73490abf427554c865bbd862976fc538cef4264bfa0e090b7da4L220-R220): Reduced the padding adjustment for the main container when no recipient is selected (`lg:pr[200px]` → `lg:pr[100px]`).
* [`src/app/recipients/page.tsx`](diffhunk://#diff-59e6d39b429c73490abf427554c865bbd862976fc538cef4264bfa0e090b7da4L306-R306): Removed the border from the main content area in table view to simplify the visual design.

### Sidebar responsiveness improvements:

* [`src/components/shared/CollapsibleSidebar.tsx`](diffhunk://#diff-e17df0ed4694e52c9d657c7e4aa15c987f5bbaf87c19d835d4d008b6c38e7b3aL142-R142): Reduced the width of the sidebar when open (`w[450px]` → `w[350px]`) and adjusted the margin (`mr-8` → `mr-2`) for better alignment.
* [`src/components/shared/CollapsibleSidebar.tsx`](diffhunk://#diff-e17df0ed4694e52c9d657c7e4aa15c987f5bbaf87c19d835d4d008b6c38e7b3aL158-R158): Reduced the padding inside the sidebar content area (`p-4` → `p-2`) to optimize spacing.

### Page layout updates:

* [`src/components/shared/PageWithStats.tsx`](diffhunk://#diff-d308f52896bd3f509509b494a670df5789413dcb26b24a8dd110287692457d62L32-R32): Increased the padding adjustment for the main content area when the sidebar is open (`lg:pr[200px]` → `lg:pr[450px]`) to accommodate the new sidebar width.