### PR TITLE
more layout updates

### DIFF
--- a/src/app/recipients/page.tsx
+++ b/src/app/recipients/page.tsx
@@ -78,10 +78,8 @@ export default function RecipientsPage() {
 	);
 
 	const handleRecipientSelect = (recipientId: Id<"recipients">) => {
-		// Only set selected recipient in table mode
-		if (viewMode === "table") {
-			setSelectedRecipientId(recipientId);
-		}
+		// Set selected recipient for both table and card modes
+		setSelectedRecipientId(recipientId);
 	};
 
 	const handleCloseDetailsPanel = () => {
@@ -131,7 +129,8 @@ export default function RecipientsPage() {
 						>
 							Add Recipient
 						</Button>
-						<div className="flex items-center gap-2">
+						{/* View mode toggle - only show on larger screens */}
+						<div className="hidden lg:flex items-center gap-2">
 							<Button
 								isIconOnly
 								variant={viewMode === "table" ? "solid" : "light"}
@@ -155,10 +154,10 @@ export default function RecipientsPage() {
 					</div>
 				</div>
 
-				{/* Main Content */}
-				<div className="flex gap-4">
-					{/* Sidebar - Large screens - More compact */}
-					<div className="hidden lg:block flex-shrink-0">
+				{/* Large Screen Layout */}
+				<div className="hidden lg:flex gap-4">
+					{/* Sidebar - Large screens */}
+					<div className="flex-shrink-0">
 						<GroupsSidebar
 							selectedGroupId={selectedGroupId}
 							onGroupSelect={setSelectedGroupId}
@@ -166,16 +165,7 @@ export default function RecipientsPage() {
 						/>
 					</div>
 
-					{/* Mobile Groups - Small screens */}
-					<div className="lg:hidden w-full mb-4">
-						<GroupsSidebar
-							selectedGroupId={selectedGroupId}
-							onGroupSelect={setSelectedGroupId}
-							className="w-full"
-						/>
-					</div>
-
-					{/* Main Content Area - Uses all available space */}
+					{/* Main Content Area */}
 					<div className="flex-1 min-w-0">
 						{viewMode === "table" ? (
 							<div className="bg-white border-default-200 rounded-lg overflow-x-auto">
@@ -186,7 +176,7 @@ export default function RecipientsPage() {
 							</div>
 						) : (
 							<div className="space-y-4">
-								{/* Cards Grid - Responsive based on available space */}
+								{/* Cards Grid */}
 								<div className="grid gap-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 p-2">
 									{paginatedRecipients.map((recipient) => (
 										<ContactCard
@@ -256,6 +246,82 @@ export default function RecipientsPage() {
 					{/* Details Panel - Right side on xl screens and above */}
 					{selectedRecipientId && (
 						<div className="hidden xl:block flex-shrink-0">
+							<RecipientDetailsPanel
+								recipientId={selectedRecipientId}
+								onClose={handleCloseDetailsPanel}
+							/>
+						</div>
+					)}
+				</div>
+
+				{/* Small Screen Layout */}
+				<div className="lg:hidden space-y-6">
+					{/* Groups */}
+					<GroupsSidebar
+						selectedGroupId={selectedGroupId}
+						onGroupSelect={setSelectedGroupId}
+						className="w-full"
+					/>
+
+					{/* Cards Grid - Always cards on mobile */}
+					<div className="space-y-4">
+						<div className="grid gap-4 grid-cols-1 sm:grid-cols-2 p-2">
+							{paginatedRecipients.map((recipient) => (
+								<ContactCard
+									key={recipient._id}
+									recipient={recipient}
+									groups={
+										groupsData && "groups" in groupsData
+											? groupsData.groups
+											: []
+									}
+									onSelect={handleRecipientSelect}
+								/>
+							))}
+						</div>
+
+						{/* Pagination */}
+						{totalPages > 1 && (
+							<div className="flex justify-center">
+								<Pagination
+									total={totalPages}
+									page={currentPage}
+									onChange={setCurrentPage}
+									showControls
+									showShadow
+									color="primary"
+								/>
+							</div>
+						)}
+
+						{/* Empty State */}
+						{filteredRecipients.length === 0 && (
+							<Card>
+								<CardBody className="text-center py-12">
+									<Users className="h-12 w-12 text-default-300 mx-auto mb-4" />
+									<h3 className="text-lg font-semibold mb-2">
+										No recipients found
+									</h3>
+									<p className="text-default-500 mb-4">
+										{searchQuery
+											? "Try adjusting your search or filters"
+											: "Get started by adding your first recipient"}
+									</p>
+									<Button
+										color="primary"
+										startContent={<Plus className="h-4 w-4" />}
+										onPress={handleAddRecipient}
+									>
+										Add Recipient
+									</Button>
+								</CardBody>
+							</Card>
+						)}
+					</div>
+
+					{/* Details Panel - Below cards on mobile */}
+					{selectedRecipientId && (
+						<div className="mt-6">
 							<RecipientDetailsPanel
 								recipientId={selectedRecipientId}
 								onClose={handleCloseDetailsPanel}

--- a/src/components/shared/CollapsibleSidebar.tsx
+++ b/src/components/shared/CollapsibleSidebar.tsx
@@ -30,7 +30,7 @@ export function CollapsibleSidebar({
 		setActiveContent(content);
 
 		// For desktop/tablet, expand the sidebar
-		if (window.innerWidth >= 768) {
+		if (window.innerWidth >= 1024) {
 			onToggle(true);
 			return;
 		}
@@ -137,7 +137,7 @@ export function CollapsibleSidebar({
 				className={`
 					h-full
 					transition-all duration-300 ease-in-out
-					hidden md:flex md:flex-col
+					hidden lg:flex lg:flex-col
 					relative
 				`}
 			>
@@ -160,7 +160,7 @@ export function CollapsibleSidebar({
 			</div>
 
 			{/* Mobile Footer Bar */}
-			<div className="fixed bottom-0 left-0 right-0 md:hidden bg-background/95 backdrop-blur-sm border-t border-divider z-50">
+			<div className="fixed bottom-0 left-0 right-0 lg:hidden bg-background/95 backdrop-blur-sm border-t border-divider z-50">
 				<div className="flex justify-around items-center py-2 px-4 safe-area-pb">
 					<SidebarIcons onIconClick={handleIconClick} />
 				</div>

--- a/src/components/shared/PageWithStats.tsx
+++ b/src/components/shared/PageWithStats.tsx
@@ -29,12 +29,12 @@ export function PageWithStats({ children }: PageWithStatsProps) {
 			{/* Desktop Grid Layout */}
 			<div
 				className={`
-					hidden md:grid w-full min-h-full
+					hidden lg:grid w-full min-h-full
 					transition-all duration-300 ease-in-out
 					${
 						isSidebarOpen
-							? "md:grid-cols-[1fr_280px] lg:grid-cols-[1fr_320px] gap-8 lg:gap-12"
-							: "md:grid-cols-[1fr_70px] gap-6"
+							? "lg:grid-cols-[1fr_280px] xl:grid-cols-[1fr_320px] gap-8 xl:gap-12"
+							: "lg:grid-cols-[1fr_70px] gap-6"
 					}
 				`}
 				style={{
@@ -53,7 +53,7 @@ export function PageWithStats({ children }: PageWithStatsProps) {
 			</div>
 
 			{/* Mobile Layout */}
-			<div className="md:hidden w-full pb-16 px-2 py-4">
+			<div className="lg:hidden w-full pb-16 px-2 py-4">
 				{children}
 				<CollapsibleSidebar
 					isOpen={isSidebarOpen}


### PR DESCRIPTION
This pull request refactors the `RecipientsPage` component and updates shared components to improve responsiveness and layout consistency across different screen sizes. Key changes include restructuring the layout for large and small screens, modifying sidebar behavior, and refining the grid system for better scalability.

### RecipientsPage Component Updates:
* Adjusted recipient selection logic to enable selection in both table and card view modes. (`src/app/recipients/page.tsx`, [src/app/recipients/page.tsxL81-L84](diffhunk://#diff-59e6d39b429c73490abf427554c865bbd862976fc538cef4264bfa0e090b7da4L81-L84))
* Introduced separate layouts for large and small screens, including dedicated card grids and pagination for mobile views. (`src/app/recipients/page.tsx`, [src/app/recipients/page.tsxR256-R331](diffhunk://#diff-59e6d39b429c73490abf427554c865bbd862976fc538cef4264bfa0e090b7da4R256-R331))
* Improved responsiveness by hiding the view mode toggle on smaller screens and restructuring the sidebar and main content layout for large screens. (`src/app/recipients/page.tsx`, [[1]](diffhunk://#diff-59e6d39b429c73490abf427554c865bbd862976fc538cef4264bfa0e090b7da4L134-R133) [[2]](diffhunk://#diff-59e6d39b429c73490abf427554c865bbd862976fc538cef4264bfa0e090b7da4L158-R168)

### Shared Components Updates:
* Updated `CollapsibleSidebar` to expand only on screens wider than 1024px and adjusted class names for consistent behavior across screen sizes. (`src/components/shared/CollapsibleSidebar.tsx`, [[1]](diffhunk://#diff-e17df0ed4694e52c9d657c7e4aa15c987f5bbaf87c19d835d4d008b6c38e7b3aL33-R33) [[2]](diffhunk://#diff-e17df0ed4694e52c9d657c7e4aa15c987f5bbaf87c19d835d4d008b6c38e7b3aL140-R140) [[3]](diffhunk://#diff-e17df0ed4694e52c9d657c7e4aa15c987f5bbaf87c19d835d4d008b6c38e7b3aL163-R163)
* Modified `PageWithStats` to use `lg` breakpoints for desktop grid layouts and `xl` for additional spacing refinements. (`src/components/shared/PageWithStats.tsx`, [[1]](diffhunk://#diff-d308f52896bd3f509509b494a670df5789413dcb26b24a8dd110287692457d62L32-R37) [[2]](diffhunk://#diff-d308f52896bd3f509509b494a670df5789413dcb26b24a8dd110287692457d62L56-R56)