### PR TITLE
restrict recipient selection to table view mode

### DIFF
--- a/src/app/recipients/page.tsx
+++ b/src/app/recipients/page.tsx
@@ -78,8 +78,10 @@ export default function RecipientsPage() {
 	);
 
 	const handleRecipientSelect = (recipientId: Id<"recipients">) => {
-		// Set selected recipient for both table and card modes
-		setSelectedRecipientId(recipientId);
+		// Only set selected recipient in table view mode
+		if (viewMode === "table") {
+			setSelectedRecipientId(recipientId);
+		}
 	};
 
 	const handleCloseDetailsPanel = () => {


### PR DESCRIPTION
This pull request includes a minor update to the `RecipientsPage` component in `src/app/recipients/page.tsx`. The change ensures that the `handleRecipientSelect` function only sets the selected recipient when the view mode is "table," improving the behavior of the selection logic.

Behavior adjustment:

* [`src/app/recipients/page.tsx`](diffhunk://#diff-59e6d39b429c73490abf427554c865bbd862976fc538cef4264bfa0e090b7da4L81-R84): Updated the `handleRecipientSelect` function to conditionally set the selected recipient based on the `viewMode` being "table."