### PR TITLE
update recipient table to display relationship and birthday on large …

### DIFF
--- a/src/components/recipients/RecipientsTable.tsx
+++ b/src/components/recipients/RecipientsTable.tsx
@@ -165,13 +165,13 @@ export function RecipientsTable({
 			{
 				key: "relation",
 				label: "Relationship",
-				className: "hidden md:table-cell",
+				className: "hidden lg:table-cell",
 			},
 			{
 				key: "birthday",
 				label: "Birthday",
 				allowsSorting: true,
-				className: "hidden md:table-cell",
+				className: "hidden lg:table-cell",
 			},
 			{
 				key: "groups",
@@ -196,7 +196,7 @@ export function RecipientsTable({
 				);
 			case "relation":
 				return (
-					<div className="hidden md:block">
+					<div className="hidden lg:block">
 						<Select
 							defaultSelectedKeys={[recipient.metadata?.relation || ""]}
 							onChange={(e) =>
@@ -214,7 +214,7 @@ export function RecipientsTable({
 				);
 			case "birthday":
 				return (
-					<div className="hidden md:block">
+					<div className="hidden lg:block">
 						<Input
 							type="date"
 							defaultValue={format(new Date(recipient.birthday), "yyyy-MM-dd")}


### PR DESCRIPTION
This pull request updates the `RecipientsTable` component to adjust visibility classes for table columns and input fields, ensuring they are hidden on medium screens (`md`) and only visible on large screens (`lg`). This change improves responsiveness and display consistency across different screen sizes.

Changes to responsiveness:

* [`src/components/recipients/RecipientsTable.tsx`](diffhunk://#diff-eee72de41688d811ae8e031e4726c19fea0094e73ec6f898e645d3a6a3bbb005L168-R174): Updated the `className` property for the "Relationship" and "Birthday" columns to use `hidden lg:table-cell` instead of `hidden md:table-cell`, ensuring these columns are visible only on large screens.
* [`src/components/recipients/RecipientsTable.tsx`](diffhunk://#diff-eee72de41688d811ae8e031e4726c19fea0094e73ec6f898e645d3a6a3bbb005L199-R199): Adjusted the `className` for the "Relationship" and "Birthday" input fields from `hidden md:block` to `hidden lg:block`, aligning their visibility behavior with the updated column settings. [[1]](diffhunk://#diff-eee72de41688d811ae8e031e4726c19fea0094e73ec6f898e645d3a6a3bbb005L199-R199) [[2]](diffhunk://#diff-eee72de41688d811ae8e031e4726c19fea0094e73ec6f898e645d3a6a3bbb005L217-R217)…screens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the recipients table so that the "relation" and "birthday" columns are now only visible on large screens and above, improving the responsive layout for smaller devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->