### PR TITLE
update recipient table to show relationship and birthday on larger sc…

### DIFF
--- a/src/components/recipients/RecipientsTable.tsx
+++ b/src/components/recipients/RecipientsTable.tsx
@@ -165,13 +165,13 @@ export function RecipientsTable({
 			{
 				key: "relation",
 				label: "Relationship",
-				className: "hidden lg:table-cell",
+				className: "hidden min-[1330px]:table-cell",
 			},
 			{
 				key: "birthday",
 				label: "Birthday",
 				allowsSorting: true,
-				className: "hidden lg:table-cell",
+				className: "hidden min-[1330px]:table-cell",
 			},
 			{
 				key: "groups",
@@ -196,7 +196,7 @@ export function RecipientsTable({
 				);
 			case "relation":
 				return (
-					<div className="hidden lg:block">
+					<div className="hidden min-[1330px]:block">
 						<Select
 							defaultSelectedKeys={[recipient.metadata?.relation || ""]}
 							onChange={(e) =>
@@ -214,7 +214,7 @@ export function RecipientsTable({
 				);
 			case "birthday":
 				return (
-					<div className="hidden lg:block">
+					<div className="hidden min-[1330px]:block">
 						<Input
 							type="date"
 							defaultValue={format(new Date(recipient.birthday), "yyyy-MM-dd")}


### PR DESCRIPTION
This pull request updates the responsive design of the `RecipientsTable` component in `src/components/recipients/RecipientsTable.tsx` by replacing `lg` breakpoints with a custom `min-[1330px]` breakpoint for better layout control.

Responsive design updates:

* Updated the `className` property for the `relation` and `birthday` columns to use `min-[1330px]:table-cell` instead of `lg:table-cell`.
* Modified the `relation` and `birthday` case blocks to use `min-[1330px]:block` instead of `lg:block` for their respective `div` elements. [[1]](diffhunk://#diff-eee72de41688d811ae8e031e4726c19fea0094e73ec6f898e645d3a6a3bbb005L199-R199) [[2]](diffhunk://#diff-eee72de41688d811ae8e031e4726c19fea0094e73ec6f898e645d3a6a3bbb005L217-R217)…reens