### PR TITLE
Refactor subscription queries in billing and recipient metadata forms…

### DIFF
--- a/convex/lib/auth.ts
+++ b/convex/lib/auth.ts
@@ -174,9 +174,11 @@ export async function authorizeAudioFileAccess(
  * @returns Promise<{user: Doc<"users">, resource: T}> - The user and resource if authorized
  * @throws ConvexError if not authenticated, user not found, or access denied
  */
-export async function authorizeResourceAccess<T extends { userId: Id<"users"> }>(
+export async function authorizeResourceAccess<
+	T extends { userId: Id<"users"> },
+>(
 	ctx: QueryCtx | MutationCtx,
-	resourceId: Id<any>,
+	resourceId: Id<"groups" | "recipients" | "customEvents" | "audioFiles">,
 	resourceType: string = "Resource"
 ): Promise<{
 	user: Doc<"users">;
@@ -184,7 +186,7 @@ export async function authorizeResourceAccess<T extends { userId: Id<"users"> }>
 }> {
 	const user = await getCurrentUser(ctx);
 
-	const resource = await ctx.db.get(resourceId) as T | null;
+	const resource = (await ctx.db.get(resourceId)) as T | null;
 	if (!resource || resource.userId !== user._id) {
 		throw new ConvexError(`${resourceType} not found or access denied`);
 	}

--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -13,7 +13,7 @@ import { useEffect, useState } from "react";
 
 export default function Page() {
 	const { userId } = useAuth();
-	const subscription = useQuery(api.subscriptions.getUserSubscription);
+	const subscription = useQuery(api.subscriptions.getActiveSubscription);
 	const [priceInfo, setPriceInfo] =
 		useState<Stripe.Response<Stripe.Price> | null>(null);
 	const getPrice = useAction(api.subscriptions.getSubscriptionPrice);

--- a/src/components/recipients/RecipientMetadataForm.tsx
+++ b/src/components/recipients/RecipientMetadataForm.tsx
@@ -98,7 +98,7 @@ export function RecipientMetadataForm({
 		api.recipients.updateRecipientMetadata
 	);
 	const updateRecipient = useMutation(api.recipients.updateRecipient);
-	const subscription = useQuery(api.subscriptions.getUserSubscription);
+	const subscription = useQuery(api.subscriptions.getActiveSubscription);
 	const isSubscriptionActive =
 		subscription && new Date(subscription.stripeCurrentPeriodEnd) > new Date();
 


### PR DESCRIPTION
This pull request introduces updates to improve authorization logic and subscription handling across multiple files. The key changes involve refining the resource access authorization function and updating subscription queries to enhance clarity and accuracy.

### Authorization Logic Improvements:
* [`convex/lib/auth.ts`](diffhunk://#diff-76d01ffd70a2d40e9d65cca6d7c30b39df38b9eb12e29924c77c52f1120dd5d0L177-R189): Updated the `authorizeResourceAccess` function to support a more specific set of resource types (`groups`, `recipients`, `customEvents`, `audioFiles`) for authorization, ensuring stricter type safety and clearer resource identification.

### Subscription Query Updates:
* [`src/app/billing/page.tsx`](diffhunk://#diff-a27af45f1be2a7100f29aa40137aea4bc71e39e4f931af3edccf4f3201b6c936L16-R16): Changed the subscription query from `getUserSubscription` to `getActiveSubscription` for more precise handling of active subscriptions in the billing page.
* [`src/components/recipients/RecipientMetadataForm.tsx`](diffhunk://#diff-48a1c80cb0c0d2c9a469e1f2ab7def33bf136a71c5eccc6a6048e758acf35704L101-R101): Updated the subscription query in the recipient metadata form to use `getActiveSubscription`, aligning it with the updated subscription logic.… to use getActiveSubscription for improved clarity and consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of subscription status checks by updating queries to retrieve only active subscriptions in billing and recipient metadata forms.

* **Refactor**
  * Enhanced authorization error messages for resource access to provide clearer feedback when access is denied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->